### PR TITLE
README: fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Cryptography
 
-[![Build Status](https://travis-ci.org/zweidenker/Cryptography.svg?branch=master)](https://travis-ci.org/zweidenker/Cryptography)
+[![Build Status](https://travis-ci.org/pharo-contributions/Cryptography.svg?branch=master)](https://travis-ci.org/pharo-contributions/Cryptography)


### PR DESCRIPTION
After migration, the repo owner in the url should be pharo-contributions.

It's a PR because apparently I don't have permissions to commit in the repo or pharo-contributions organization.